### PR TITLE
fix: add h5n1 seg3 back to index

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -211,6 +211,29 @@
           }
         },
         {
+          "path": "flu/h5n1/seg3",
+          "enabled": true,
+          "attributes": {
+            "name": "Influenza A/H5N1 (segment 3/PA)",
+            "reference name": "Influenza A virus (A/goose/Guangdong/1/1996(H5N1)) polymerase (PA) and PA-X protein (PA-X) genes, complete cds",
+            "reference accession": "NC_007359.1"
+          },
+          "files": {
+            "reference": "reference.fasta",
+            "pathogenJson": "pathogen.json",
+            "genomeAnnotation": "genome_annotation.gff3",
+            "readme": "README.md"
+          },
+          "versions": [
+            {
+              "tag": "unreleased"
+            }
+          ],
+          "version": {
+            "tag": "unreleased"
+          }
+        },
+        {
           "path": "cchfv/L",
           "enabled": true,
           "files": {


### PR DESCRIPTION
sequence ID etc. taken from here: https://github.com/GenSpectrum/nextclade-datasets/pull/9/changes#diff-cf904c3b3dbb054d78c122ac10b09f0384c652a65a53a8542e90219dbbf9460bL214